### PR TITLE
Add a `clean` rule

### DIFF
--- a/jakelib/clean.jake
+++ b/jakelib/clean.jake
@@ -1,0 +1,10 @@
+'use strict';
+
+var config = require('./config');
+
+task('clean', function() {
+  jake.rmRf(config.WEBRTC_OUT);
+  jake.rmRf(config.OUT_INCLUDE);
+  jake.rmRf(config.OUT_LIB);
+  jake.rmRf(config.OUT_COMMIT);
+});

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build-webrtc": "jake build-webrtc",
     "checkout-depot_tools": "jake checkout-depot_tools",
     "checkout-webrtc": "jake checkout-webrtc",
+    "clean": "jake clean",
     "copy-webrtc": "jake copy-webrtc",
     "copy-webrtc-headers": "jake copy-webrtc-headers",
     "install": "jake",


### PR DESCRIPTION
It is useful to run this when updating webrtc because creating `libwebrtc.a` is done by merging `*.o` files. When updating from v50 to v51 for example, some of those files are no longer produced, but if old `.o` files are laying around they will get merged with the new ones, which will cause linking errors.