### PR TITLE
Update to webrtc v56

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -6,7 +6,7 @@
   },
   "webrtc": {
     "checkout": "webrtc",
-    "ref": "branch-heads/50",
+    "ref": "branch-heads/56",
     "repo": "https://chromium.googlesource.com/external/webrtc.git"
   },
   "out": ".",

--- a/jakelib/build-webrtc.jake
+++ b/jakelib/build-webrtc.jake
@@ -15,7 +15,7 @@ var WEBRTC_OUT = config.WEBRTC_OUT;
 
 directory(OUT_LIB);
 
-task('build-webrtc', ['checkout-webrtc', OUT_LIB], function() {
+task('build-webrtc', ['checkout-webrtc', 'gen-ninja-cfg', OUT_LIB], function() {
   log('Running ninja');
   ninja(WEBRTC_OUT, { cwd: WEBRTC_CHECKOUT_SRC });
 

--- a/jakelib/config.js
+++ b/jakelib/config.js
@@ -34,6 +34,7 @@ var DEPOT_TOOLS_CHECKOUT = resolve(process.env.DEPOT_TOOLS_CHECKOUT || DEFAULT_D
 var DEPOT_TOOLS_REPO = process.env.DEPOT_TOOLS_REPO || DEFAULT_DEPOT_TOOLS_REPO;
 var GCLIENT = path.join(DEPOT_TOOLS_CHECKOUT, 'gclient');
 var NINJA = path.join(DEPOT_TOOLS_CHECKOUT, 'ninja');
+var GN = path.join(DEPOT_TOOLS_CHECKOUT, 'gn');
 var PYTHON = PLATFORM === 'win32' ? path.join(DEPOT_TOOLS_CHECKOUT, 'python.bat') : 'python';
 
 var OUT = resolve(process.env.OUT || DEFAULT_OUT);
@@ -87,6 +88,7 @@ exports.CONFIGURATION = CONFIGURATION;
 exports.DEPOT_TOOLS_CHECKOUT = DEPOT_TOOLS_CHECKOUT;
 exports.DEPOT_TOOLS_REPO = DEPOT_TOOLS_REPO;
 exports.GCLIENT = GCLIENT;
+exports.GN = GN;
 exports.NINJA = NINJA;
 exports.OUT = OUT;
 exports.OUT_COMMIT = OUT_COMMIT;

--- a/jakelib/gen-ninja-cfg.jake
+++ b/jakelib/gen-ninja-cfg.jake
@@ -1,3 +1,4 @@
+/* global desc:false, task:false */
 'use strict';
 
 var gn = require('./gn');

--- a/jakelib/gen-ninja-cfg.jake
+++ b/jakelib/gen-ninja-cfg.jake
@@ -1,0 +1,14 @@
+'use strict';
+
+var gn = require('./gn');
+var config = require('./config');
+var log = require('./log');
+
+var WEBRTC_OUT = config.WEBRTC_OUT;
+var WEBRTC_CHECKOUT_SRC = config.WEBRTC_CHECKOUT_SRC;
+
+desc('Generate ninja config');
+task('gen-ninja-cfg', function() {
+  log('Running gn');
+  gn(WEBRTC_OUT, { cwd: WEBRTC_CHECKOUT_SRC });
+});

--- a/jakelib/gn.js
+++ b/jakelib/gn.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var config = require('./config');
-var execSync = require('child_process').execSync;
+var execFileSync = require('child_process').execFileSync;
 
 var GN = config.GN;
 
@@ -16,9 +16,9 @@ function gn(cwd, execOptions) {
     stdio: 'inherit'
   }, execOptions);
 
-  var cmd = GN + ' gen ' + cwd + ' --args=\'is_debug=' + (config.CONFIGURATION !== 'Release') + ' rtc_include_tests=false\'';
+  var args = ['gen', cwd, '--args=is_debug=' + (config.CONFIGURATION !== 'Release') + ' rtc_include_tests=false'];
 
-  return execSync(cmd, execOptions);
+  return execFileSync(GN, args, execOptions);
 }
 
 module.exports = gn;

--- a/jakelib/gn.js
+++ b/jakelib/gn.js
@@ -16,7 +16,7 @@ function gn(cwd, execOptions) {
     stdio: 'inherit'
   }, execOptions);
 
-  var cmd = GN + ' gen ' + cwd + ' --args=\'is_debug=' + (config.CONFIGURATION !== 'Release') + '\'';
+  var cmd = GN + ' gen ' + cwd + ' --args=\'is_debug=' + (config.CONFIGURATION !== 'Release') + ' rtc_include_tests=false\'';
 
   return execSync(cmd, execOptions);
 }

--- a/jakelib/gn.js
+++ b/jakelib/gn.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var config = require('./config');
+var execSync = require('child_process').execSync;
+
+var GN = config.GN;
+
+/**
+ * Run gn.
+ * @param {string} cwd - the directory to run gn in
+ * @param {object} [execOptions] - exec options
+ * @returns {Buffer|String} - the stdout from the command
+ */
+function gn(cwd, execOptions) {
+  execOptions = Object.assign({
+    stdio: 'inherit'
+  }, execOptions);
+
+  var cmd = GN + ' gen ' + cwd + ' --args=\'is_debug=' + (config.CONFIGURATION !== 'Release') + '\'';
+
+  return execSync(cmd, execOptions);
+}
+
+module.exports = gn;

--- a/jakelib/lint.jake
+++ b/jakelib/lint.jake
@@ -1,9 +1,9 @@
 /* global desc:false, task:false */
 'use strict';
 
-var execSync = require('child_process').execSync;
+var execFileSync = require('child_process').execFileSync;
 
 desc('Lint the build scripts');
 task('lint', function() {
-  execSync('npm run lint', { stdio: 'inherit' });
+  execFileSync('npm', ['run', 'lint'], { stdio: 'inherit' });
 });

--- a/jakelib/ninja.js
+++ b/jakelib/ninja.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var config = require('./config');
-var execSync = require('child_process').execSync;
+var execFileSync = require('child_process').execFileSync;
 
 var NINJA = config.NINJA;
 
@@ -16,9 +16,9 @@ function ninja(cwd, execOptions) {
     stdio: 'inherit'
   }, execOptions);
 
-  var cmd = NINJA + ' -C ' + cwd;
+  var args = ['-C', cwd];
 
-  return execSync(cmd, execOptions);
+  return execFileSync(NINJA, args, execOptions);
 }
 
 module.exports = ninja;


### PR DESCRIPTION
The build process now [relies on the tool `gn`](https://webrtc.org/native-code/development/) whereas version 50 [used `gyp`](https://web.archive.org/web/20160323234502/http://webrtc.org/native-code/development/).